### PR TITLE
Refactor WorkoutItem structure for flexibility

### DIFF
--- a/app/src/lib/exerciseData.test.ts
+++ b/app/src/lib/exerciseData.test.ts
@@ -66,13 +66,11 @@ describe('getRandomExercises', () => {
         expect(workoutItems).toHaveLength(3);
     });
 
-    it('should return workout items with default values', () => {
+    it('should return workout items with default not completed value', () => {
         const workoutItems = getRandomWorkoutItems(1);
         const item = workoutItems[0];
         
         expect(item).toHaveProperty('exercise');
-        expect(item).toHaveProperty('sets', 3);
-        expect(item).toHaveProperty('reps', 12);
         expect(item).toHaveProperty('completed', false);
     });
 

--- a/app/src/lib/exerciseData.ts
+++ b/app/src/lib/exerciseData.ts
@@ -118,8 +118,6 @@ export function getRandomWorkoutItems(count: number = 5): WorkoutItem[] {
     const exercises = getRandomExercises(count);
     return exercises.map(exercise => ({
         exercise,
-        sets: 3, // These default values will be overridden by the UI
-        reps: 12,
         completed: false
     }));
 }

--- a/app/src/lib/types.ts
+++ b/app/src/lib/types.ts
@@ -27,7 +27,7 @@ export interface ExerciseDetails {
  */
 export interface WorkoutItem {
   exercise: ExerciseDetails;
-  sets: number;
+  sets?: number;
   reps?: number;
   weight?: number;
   time?: string;


### PR DESCRIPTION
Remove default sets and reps values from WorkoutItem to enhance flexibility in workout configurations. Adjust related tests to reflect these changes.