### PR TITLE
Add formatting utility for muscle groups in recovery page

### DIFF
--- a/app/src/lib/formatting.test.ts
+++ b/app/src/lib/formatting.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+import { formatMuscleGroup } from "$lib/formatting";
+
+describe("formatting utils", () => {
+  describe("formatMuscleGroup", () => {
+    it("should capitalize the first letter of each word", () => {
+      expect(formatMuscleGroup("upper_body")).toBe("Upper Body");
+      expect(formatMuscleGroup("lower_body")).toBe("Lower Body");
+      expect(formatMuscleGroup("core")).toBe("Core");
+    });
+
+    it("should handle empty strings", () => {
+      expect(formatMuscleGroup("")).toBe("");
+    });
+
+    it("should handle strings with multiple underscores", () => {
+      expect(formatMuscleGroup("very_long_muscle_group_name")).toBe(
+        "Very Long Muscle Group Name",
+      );
+    });
+  });
+});

--- a/app/src/lib/formatting.ts
+++ b/app/src/lib/formatting.ts
@@ -1,0 +1,18 @@
+/**
+ * Formatting utilities for consistent UI presentation
+ */
+
+/**
+ * Format muscle group for display by:
+ * 1. Replacing underscores with spaces
+ * 2. Capitalizing the first letter of each word
+ *
+ * @param muscleGroup - The muscle group string to format (e.g., "upper_body")
+ * @returns Formatted string (e.g., "Upper Body")
+ */
+export function formatMuscleGroup(muscleGroup: string): string {
+  return muscleGroup
+    .split("_")
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+}

--- a/app/src/lib/recovery.ts
+++ b/app/src/lib/recovery.ts
@@ -1,3 +1,7 @@
+import { musclesList, type Muscles } from "$lib/muscles";
+import { getCompletedExercisesByDateRange } from "$lib/database";
+import { getExerciseById } from "$lib/exercises";
+
 /**
  * Constants for recovery calculations
  */
@@ -23,11 +27,6 @@ export interface MuscleRecovery {
   recoveryPercentage: number;
   exerciseCount: number; // Number of exercises performed during recovery period
 }
-
-import { musclesList } from "$lib/muscles";
-import type { Muscles } from "$lib/muscles";
-import { getCompletedExercisesByDateRange } from "$lib/database";
-import { getExerciseById } from "$lib/exercises";
 
 /**
  * Calculate the recovery percentage for a muscle based on last trained date and recovery hours

--- a/app/src/routes/recovery/+page.svelte
+++ b/app/src/routes/recovery/+page.svelte
@@ -6,6 +6,7 @@
     MuscleRecoveryStatus,
     type MuscleRecovery,
   } from "$lib/recovery";
+  import { formatMuscleGroup } from "$lib/formatting";
 
   const recoveryStatusColors = {
     [MuscleRecoveryStatus.RECOVERING]: {
@@ -51,6 +52,7 @@
 
     // Sort muscles into their groups
     muscleRecovery.forEach((muscle) => {
+      // format the muscle group to remove
       const muscleGroup = muscle.muscleGroup;
       if (muscleGroup in grouped) {
         grouped[muscleGroup as MuscleGroups].push(muscle);
@@ -76,7 +78,6 @@
     const lookBackDays = 14; // Look back 14 days
     try {
       muscleRecovery = await getMuscleRecoveryStatusForAllMuscles(lookBackDays);
-      console.log("Muscle Recovery Data:", muscleRecovery);
 
       isLoading = false;
     } catch (err) {
@@ -207,7 +208,7 @@
                 class="text-lg font-bold text-blue-400"
                 id="muscle-group-{muscleGroup.replace(/\s+/g, '-')}"
               >
-                {muscleGroup.charAt(0).toUpperCase() + muscleGroup.slice(1)}
+                {formatMuscleGroup(muscleGroup)}
               </td>
             </tr>
 


### PR DESCRIPTION
Introduce a utility to format muscle group names for consistent UI presentation and integrate it into the recovery page. This enhances readability by capitalizing words and replacing underscores with spaces.